### PR TITLE
make run.sh Linux compatible

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -8,6 +8,9 @@ mvn clean install
 # Export the active docker machine IP
 export DOCKER_IP=$(docker-machine ip $(docker-machine active))
 
+# docker-machine doesn't exist in Linux, assign default ip if it's not set
+DOCKER_IP=${DOCKER_IP:-0.0.0.0}
+
 # Remove existing containers
 docker-compose stop
 docker-compose rm -f


### PR DESCRIPTION
`docker-machine` is not relevant for Linux distros so it doesn't exists in Ubuntu for example. Consequently the script hangs in infinite loop because `nc` command is invalid with an empty `DOCKER_IP`.
