### PR TITLE
Setting explicit third party Docker image versions plus Windows script support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,24 +13,24 @@ hystrix-dashboard:
   ports:
    - 6161:6161
 mysql:
-  image: mysql:latest
+  image: mysql:5.7
   ports:
    - 3306:3306
   environment:
    - MYSQL_ROOT_PASSWORD=dbpass
    - MYSQL_DATABASE=dev
 neo4j:
-  image: neo4j:latest
+  image: neo4j:2.3
   ports:
    - 7474:7474
   environment:
    - NEO4J_AUTH=none
 mongo:
-  image: mongo:latest
+  image: mongo:3.3
   ports:
    - 27017:27017
 redis:
-  image: redis:latest
+  image: redis:3.0
   ports:
    - 6379:6379
 user-service:

--- a/run.sh
+++ b/run.sh
@@ -20,7 +20,7 @@ docker-compose up -d config-service
 
 while [ -z ${CONFIG_SERVICE_READY} ]; do
   echo "Waiting for config service..."
-  if [ "$(nc $DOCKER_IP -z -w 4 8888; echo $?)" = 0 ]; then
+  if [ "$(curl --silent $DOCKER_IP:8888/health 2>&1 | grep -q '\"status\":\"UP\"'; echo $?)" = 0 ]; then
       CONFIG_SERVICE_READY=true;
   fi
   sleep 2
@@ -31,7 +31,7 @@ docker-compose up -d discovery-service
 
 while [ -z ${DISCOVERY_SERVICE_READY} ]; do
   echo "Waiting for discovery service..."
-  if [ "$(nc $DOCKER_IP -z -w 4 8761; echo $?)" = 0 ]; then
+  if [ "$(curl --silent $DOCKER_IP:8761/health 2>&1 | grep -q '\"status\":\"UP\"'; echo $?)" = 0 ]; then
       DISCOVERY_SERVICE_READY=true;
   fi
   sleep 2


### PR DESCRIPTION
Hi,

thanks for the excellent work. This is by far the most comprehensive worked example I've seen of Spring Microservices in general and event sourcing in particular.

Just a couple of issues I noticed while trying to run it. The latest neo4j docker image is version 3.0.0 and causes the Inventory service to fail during startup with the following error:

```
inventory-service_1      | Caused by: java.lang.RuntimeException: com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "meta" (class org.neo4j.ogm.session.result.RowModelResult), not marked as ignorable (one known property: "row"])
inventory-service_1      |  at [Source: {"row":[0],"meta":[null]}]}; line: 1, column: 20] (through reference chain: org.neo4j.ogm.session.result.RowModelResult["meta"])
inventory-service_1      |  at org.neo4j.ogm.session.response.RowModelResponse.next(RowModelResponse.java:48)
inventory-service_1      |  at org.neo4j.ogm.session.response.SessionResponseHandler.updateObjects(SessionResponseHandler.java:93)
inventory-service_1      |  at org.neo4j.ogm.session.delegates.SaveDelegate.save(SaveDelegate.java:69)
inventory-service_1      |  at org.neo4j.ogm.session.delegates.SaveDelegate.save(SaveDelegate.java:43)
inventory-service_1      |  at org.neo4j.ogm.session.Neo4jSession.save(Neo4jSession.java:386)
inventory-service_1      |  at org.springframework.data.neo4j.repository.GraphRepositoryImpl.save(GraphRepositoryImpl.java:53)
inventory-service_1      |  at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
inventory-service_1      |  at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
inventory-service_1      |  at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
inventory-service_1      |  at java.lang.reflect.Method.invoke(Method.java:498)
inventory-service_1      |  at org.springframework.data.repository.core.support.RepositoryFactorySupport$QueryExecutorMethodInterceptor.executeMethodOn(RepositoryFactorySupport.java:483)
inventory-service_1      |  at org.springframework.data.repository.core.support.RepositoryFactorySupport$QueryExecutorMethodInterceptor.doInvoke(RepositoryFactorySupport.java:468)
inventory-service_1      |  at org.springframework.data.repository.core.support.RepositoryFactorySupport$QueryExecutorMethodInterceptor.invoke(RepositoryFactorySupport.java:440)
inventory-service_1      |  at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:179)
inventory-service_1      |  at org.springframework.data.projection.DefaultMethodInvokingMethodInterceptor.invoke(DefaultMethodInvokingMethodInterceptor.java:61)
inventory-service_1      |  at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:179)
inventory-service_1      |  at org.springframework.transaction.interceptor.TransactionInterceptor$1.proceedWithInvocation(TransactionInterceptor.java:99)
inventory-service_1      |  at org.springframework.transaction.interceptor.TransactionAspectSupport.invokeWithinTransaction(TransactionAspectSupport.java:281)
inventory-service_1      |  at org.springframework.transaction.interceptor.TransactionInterceptor.invoke(TransactionInterceptor.java:96)
inventory-service_1      |  at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:179)
inventory-service_1      |  at org.springframework.dao.support.PersistenceExceptionTranslationInterceptor.invoke(PersistenceExceptionTranslationInterceptor.java:136)
inventory-service_1      |  at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:179)
inventory-service_1      |  at org.springframework.aop.interceptor.ExposeInvocationInterceptor.invoke(ExposeInvocationInterceptor.java:92)
inventory-service_1      |  at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:179)
inventory-service_1      |  at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:208)
inventory-service_1      |  at com.sun.proxy.$Proxy111.save(Unknown Source)
inventory-service_1      |  at demo.config.DatabaseInitializer.populate(DatabaseInitializer.java:92)
inventory-service_1      |  at demo.InventoryApplication.lambda$commandLineRunner$0(InventoryApplication.java:45)
inventory-service_1      |  at org.springframework.boot.SpringApplication.callRunner(SpringApplication.java:806)
inventory-service_1      |  ... 12 more
```

Setting explicit versions for the third party images solves the problem.

The second thing was that netcat doesn't exist in the default install of Cywin / Docker Quickstart terminal on Windows, so the script just loops infinitely while checking if the Config service is up.
Curl does exist, so curling the Spring Boot Actuator's health endpoint provides the same check, but should work on Windows, Mac and Linux.

Thanks,
Barry
