### PR TITLE
Updated run.sh to support Windows/Cygwin

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -20,7 +20,7 @@ docker-compose up -d config-service
 
 while [ -z ${CONFIG_SERVICE_READY} ]; do
   echo "Waiting for config service..."
-  if [ "$(nc $DOCKER_IP -z -w 4 8888; echo $?)" = 0 ]; then
+  if [ "$(curl --silent $DOCKER_IP:8888/health 2>&1 | grep -q '\"status\":\"UP\"'; echo $?)" = 0 ]; then
       CONFIG_SERVICE_READY=true;
   fi
   sleep 2
@@ -31,7 +31,7 @@ docker-compose up -d discovery-service
 
 while [ -z ${DISCOVERY_SERVICE_READY} ]; do
   echo "Waiting for discovery service..."
-  if [ "$(nc $DOCKER_IP -z -w 4 8761; echo $?)" = 0 ]; then
+  if [ "$(curl --silent $DOCKER_IP:8761/health 2>&1 | grep -q '\"status\":\"UP\"'; echo $?)" = 0 ]; then
       DISCOVERY_SERVICE_READY=true;
   fi
   sleep 2


### PR DESCRIPTION
Hi,

Spotted an issue while trying to run the run.sh script on Windows.

netcat doesn't exist in the default install of Cywin / Docker Quickstart terminal on Windows, so the script just loops infinitely while checking if the Config service is up.
Curl does exist, so curling the Spring Boot Actuator's health endpoint provides the same check, but should work on Windows, Mac and Linux.
