### PR TITLE
fix config-server ip of discovery-service in docker env

### DIFF
--- a/discovery-service/src/main/resources/bootstrap.yml
+++ b/discovery-service/src/main/resources/bootstrap.yml
@@ -3,3 +3,10 @@ server:
 spring:
   application:
     name: discovery-service
+
+---
+spring:
+  profiles: docker
+  cloud:
+    config:
+      uri: http://${DOCKER_IP:192.168.99.100}:8888


### PR DESCRIPTION
when I run "run.sh" on my mac in docker-terminal, I got an error log saying 
"discovery-service" cannot look up "config-server" in http://localhost:8888 which should be 'DOCKER-IP:888' in  docker env case.
